### PR TITLE
Fix 'Open this doc on GitHub' 404 errors

### DIFF
--- a/_includes/body.html
+++ b/_includes/body.html
@@ -18,8 +18,18 @@
                         {{ content }}
                         {% assign dirpath = page.path | split: "/" %}
                         {% if dirpath[0] == "docs" %}
-                        <a href="https://github.com/enso-org/enso/blob/main/{{page.path}}">Open this doc on GitHub</a>
+                          {% if dirpath[1] == "enso" %}
+                            {% assign githubpath = page.path | remove:'docs/enso/' %}
+                            <a href="https://github.com/enso-org/enso/blob/main/docs/{{githubpath}}">Open this doc on GitHub</a>
+                          {% elsif dirpath[1] == "ide" %}
+                            {% assign githubpath = page.path | remove:'docs/ide/' %}
+                            <a href="https://github.com/enso-org/ide/blob/main/docs/{{githubpath}}">Open this doc on GitHub</a>
+                          {% else %}
+                            {% assign githubpath = page.path | remove:'docs/' %}
+                            <a href="https://github.com/enso-org/enso-org.github.io/tree/sources/docs/{{githubpath}}">Open this doc on GitHub</a>
+                          {% endif %}
                         {% endif %}
+
                     </section>
                 </div>
 


### PR DESCRIPTION
### Pull Request Description
Fixes https://github.com/enso-org/enso-org.github.io/issues/30. 

The link on https://dev.enso.org/docs/ actually currently leads to the wrong page because everything is currently going to `https://github.com/enso-org/enso/blob/main/{{page.path}}`. All `ide` links (`https://dev.enso.org/docs/ide`) are broken for the same reason and the links for `enso` have an erroneous `/docs/enso`.

There's probably a prettier way of writing the logic but this is the logic needed.

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code has been tested where possible.
